### PR TITLE
Update generate_quote & add_project w/ empty referencefiles & error reponse COM-346

### DIFF
--- a/add_project.rst
+++ b/add_project.rst
@@ -310,7 +310,7 @@ Request Body
 |      .AssetID           |                         |                                 |
 |                         |                         |                                 |
 +-------------------------+-------------------------+---------------------------------+
-        
+
 
 
 Product Request Example
@@ -343,7 +343,7 @@ Product Request Example
                 <CategoryPath>Clothing : Menswear : Shoes</CategoryPath>
                 <Description>
                     <!--
-                        This can be an XML block containing arbitrary, 
+                        This can be an XML block containing arbitrary,
                         well formed sub elements.
                     -->
 
@@ -471,7 +471,7 @@ Response Body
 =============
 
 The response body contains a quote for a project. Please note: the response may
-not contain a price.  If the submitted files 
+not contain a price.  If the submitted files
 
 +-------------------------+-------------------------+-------------------------+
 | Property                | Type                    | Comments                |
@@ -568,7 +568,7 @@ not contain a price.  If the submitted files
 |                         |                         |                         |
 |      .Product           |                         |                         |
 |                         |                         |                         |
-|      .SKUs              |                         |                         | 
+|      .SKUs              |                         |                         |
 +-------------------------+-------------------------+-------------------------+
 | .. container:: notrans  | Container               | Container of a SKU      |
 |                         |                         |                         |
@@ -706,16 +706,18 @@ Product-Based Project Response Example
         <Currency>EUR</Currency>
 
         <Products>
-                <Product>
-                    <AssetID>999</AssetID>
-                    <SKUs>
-                        <SKU>
-                            <SKUNumber>123</SKUNumber>
-                        </SKU>
-                    </SKUs>
-                    <DueDate>2014-02-11T10:22:46Z</DueDate> 
-                </Product>
-            </Products>
+            <Product>
+                <AssetID>999</AssetID>
+                <SKUs>
+                    <SKU>
+                        <SKUNumber>123</SKUNumber>
+                    </SKU>
+                </SKUs>
+                <DueDate>2014-02-11T10:22:46Z</DueDate>
+            </Product>
+        </Products>
+        <ReferenceFiles/>
+        <Errors></Errors>
     </Project>
 
 If the price is not yet ready, the response will look like:
@@ -752,6 +754,8 @@ If the price is not yet ready, the response will look like:
                 </SKUs>
             </Product>
         </Products>
+        <ReferenceFiles/>
+        <Errors></Errors>
     </Project>
 
 File-Based Project Response Example
@@ -785,6 +789,9 @@ File-Based Project Response Example
                 <FileName>example.txt</FileName>
             </File>
         </Files>
+
+        <ReferenceFiles/>
+        <Errors></Errors>
     </Project>
 
 If the price is not yet ready, the response will look like:
@@ -813,11 +820,14 @@ If the price is not yet ready, the response will look like:
         <Currency>EUR</Currency>
 
         <Files>
-                <File>
-                    <AssetID>999</AssetID>
-                    <FileName>example.txt</FileName>
-                </File>
+            <File>
+                <AssetID>999</AssetID>
+                <FileName>example.txt</FileName>
+            </File>
         </Files>
+
+        <ReferenceFiles/>
+        <Errors></Errors>
     </Project>
 
 If one of or more files submitted are not compatible with the selected service, the response will look like
@@ -836,7 +846,7 @@ If one of or more files submitted are not compatible with the selected service, 
 Errors
 ======
 If generate quote encountered an error, the response will contain an Error element consisting of
-a ReasonCode, SimpleMessage, and DetailedMessage elements. See :doc:`error_handling` for more 
+a ReasonCode, SimpleMessage, and DetailedMessage elements. See :doc:`error_handling` for more
 information. Here are some common cases.
 
 +-------------------------+-------------------------+-------------------------+
@@ -891,4 +901,3 @@ information. Here are some common cases.
 |                         |                         |                         |
 |                         |                         | this project            |
 +-------------------------+-------------------------+-------------------------+
-

--- a/generate_quote.rst
+++ b/generate_quote.rst
@@ -918,6 +918,7 @@ Product-Based Quote Response Example
                     </ReferenceFiles>
                 </Project>
         </Projects>
+        <Errors></Errors>
     </Quote>
 
 If the price is not yet ready, the response will look like:
@@ -977,6 +978,7 @@ If the price is not yet ready, the response will look like:
                     </ReferenceFiles>
                 </Project>
         </Projects>
+        <Errors></Errors>
     </Quote>
 
 File-Based Quote Response Example
@@ -1033,6 +1035,7 @@ File-Based Quote Response Example
                     </ReferenceFiles>
                 </Project>
         </Projects>
+        <Errors></Errors>
     </Quote>
 
 If the price is not yet ready, the response will look like:
@@ -1071,6 +1074,7 @@ If the price is not yet ready, the response will look like:
                 </ReferenceFiles>
             </Project>
         </Projects>
+        <Errors></Errors>
     </Quote>
 
 If one of or more files submitted are not compatible with the selected service, the response will look like
@@ -1117,8 +1121,11 @@ Project Based Quote Response Example
                                     <LanguageCode>fr-fr</LanguageCode>
                                 </TargetLanguage>
                     </TargetLanguages>
+                <ReferenceFiles/>
                 </Project>
         </Projects>
+
+        <Errors></Errors>
     </Quote>
 
 If the price is not yet ready, the response will look like:
@@ -1150,8 +1157,11 @@ If the price is not yet ready, the response will look like:
                                     <LanguageCode>fr-fr</LanguageCode>
                                 </TargetLanguage>
                     </TargetLanguages>
+                    <ReferenceFiles/>
                 </Project>
         </Projects>
+
+        <Errors></Errors>
     </Quote>
 
 If one of or more of the projects is already included in another quote, the response will look like this:


### PR DESCRIPTION
Add the empty elements in the response
```
        <ReferenceFiles/>
        <Errors></Errors>
```

This is for the QA API regression test on [COM-346](https://liondemand.atlassian.net/browse/COM-346).

Instead of updating our od_api code to exclude ReferenceFiles & Errors in the Serializers or Views, we can just update the docs to follow our output.

Need to update the other versions as well:

- Version 2014-09-04

- Version 2014-06-10

- Version 2014-02-28
